### PR TITLE
[fix] access token, refresh token 쿠키에서 발급

### DIFF
--- a/src/main/java/com/example/oauthjwt/config/SecurityConfig.java
+++ b/src/main/java/com/example/oauthjwt/config/SecurityConfig.java
@@ -3,6 +3,7 @@ package com.example.oauthjwt.config;
 
 import com.example.oauthjwt.oauth2.api.OAuthLoginFailureHandler;
 import com.example.oauthjwt.oauth2.api.OAuthLoginSuccessHandler;
+import com.example.oauthjwt.oauth2.infra.jwt.JWTFilter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -11,6 +12,7 @@ import org.springframework.security.config.annotation.web.configuration.EnableWe
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.annotation.web.configurers.HttpBasicConfigurer;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 
@@ -22,6 +24,7 @@ import java.util.Collections;
 public class SecurityConfig {
     private final OAuthLoginSuccessHandler oAuthLoginSuccessHandler;
     private final OAuthLoginFailureHandler oAuthLoginFailureHandler;
+    private final JWTFilter jwtFilter;
 
     // CORS 설정
     CorsConfigurationSource corsConfigurationSource() {
@@ -50,7 +53,8 @@ public class SecurityConfig {
                         oauth
                                 .successHandler(oAuthLoginSuccessHandler) // 로그인 성공 시 핸들러
                                 .failureHandler(oAuthLoginFailureHandler) // 로그인 실패 시 핸들러
-                );
+                )
+                .addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class); // JWTFilter를 인증 필터 전에 추가;
 
         return httpSecurity.build();
     }

--- a/src/main/java/com/example/oauthjwt/oauth2/api/OAuthLoginSuccessHandler.java
+++ b/src/main/java/com/example/oauthjwt/oauth2/api/OAuthLoginSuccessHandler.java
@@ -7,6 +7,7 @@ import com.example.oauthjwt.user.domain.entity.User;
 import com.example.oauthjwt.oauth2.infra.jwt.JWTUtil;
 import com.example.oauthjwt.oauth2.domain.repository.RefreshTokenRepository;
 import com.example.oauthjwt.user.domain.repository.UserRepository;
+import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
@@ -64,9 +65,10 @@ public class OAuthLoginSuccessHandler extends SimpleUrlAuthenticationSuccessHand
         // 정보 추출
         String providerId = oAuth2UserInfo.getProviderId();
         String name = oAuth2UserInfo.getName();
+        log.info(providerId);
 
         // 1. Optional<User>로 처리
-        Optional<User> optionalUser = userRepository.findByProviderId(providerId);
+        Optional<User> optionalUser = userRepository.findByProvider(providerId);
         User user;
 
         if (optionalUser.isEmpty()) {
@@ -93,12 +95,27 @@ public class OAuthLoginSuccessHandler extends SimpleUrlAuthenticationSuccessHand
 
             // 액세스 토큰 발급
             String accessToken = jwtUtil.generateAccessToken(user.getUserId(), ACCESS_TOKEN_EXPIRATION_TIME);
+            // 액세스 토큰과 리프레시 토큰을 쿠키에 저장
+            addCookie(request,response, "accessToken", accessToken, (int) ACCESS_TOKEN_EXPIRATION_TIME / 1000);
+            addCookie(request,response, "refreshToken", refreshToken, (int) REFRESH_TOKEN_EXPIRATION_TIME / 1000);
 
-            // 리다이렉트 처리
-            String encodedName = URLEncoder.encode(name, "UTF-8");
-            String redirectUri = String.format(ACCESS_TOKEN_REDIRECT_URI, encodedName, accessToken, refreshToken);
-            getRedirectStrategy().sendRedirect(request, response, redirectUri);
+            // 리다이렉트 처리 (쿠키로 토큰 전달했으므로 토큰을 쿼리로 전달할 필요 없음)
+            getRedirectStrategy().sendRedirect(request, response, ACCESS_TOKEN_REDIRECT_URI);
         }
+    }
+    // 쿠키 추가 메서드
+    private void addCookie(HttpServletRequest request, HttpServletResponse response, String name, String value, int maxAge) {
+        Cookie cookie = new Cookie(name, value);
+        cookie.setHttpOnly(true);  // XSS 공격 방지
+
+        // 로컬에서는 Secure 속성 사용 안함 (배포 환경에서는 true로 설정)
+        cookie.setSecure(!"localhost".equals(request.getServerName()));
+
+        cookie.setPath("/");       // 모든 경로에서 접근 가능
+        cookie.setMaxAge(maxAge);  // 쿠키 유효기간 설정
+
+        // 쿠키를 응답에 추가
+        response.addCookie(cookie);
     }
 }
 

--- a/src/main/java/com/example/oauthjwt/oauth2/api/TokenController.java
+++ b/src/main/java/com/example/oauthjwt/oauth2/api/TokenController.java
@@ -4,26 +4,39 @@ import com.example.oauthjwt.common.dto.ApiResponse;
 import com.example.oauthjwt.common.exception.enums.SuccessStatus;
 import com.example.oauthjwt.common.dto.TokenResponse;
 import com.example.oauthjwt.oauth2.application.service.TokenService;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestHeader;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/v1")
 @RequiredArgsConstructor
 public class TokenController {
+    @Value("${jwt.access-token.expiration-time}")
+    private long ACCESS_TOKEN_EXPIRATION_TIME;
     private final TokenService authService;
 
-    // 액세스 토큰을 재발행하는 API
+    // 액세스 토큰을 재발행하는 API (쿠키 방식)
     @GetMapping("/reissue/access-token")
     public ResponseEntity<ApiResponse<Object>> reissueAccessToken(
-            @RequestHeader("Authorization") String authorizationHeader) {
+            @CookieValue(value = "refreshToken", required = false) String refreshTokenCookie, // 쿠키에서 리프레시 토큰 가져옴
+            HttpServletResponse response) {
 
-        TokenResponse accessToken = authService.reissueAccessToken(authorizationHeader);
-        return ApiResponse.onSuccess(SuccessStatus._CREATED_ACCESS_TOKEN, accessToken);
+        // 서비스에서 액세스 토큰 재발급 처리
+        TokenResponse accessToken = authService.reissueAccessToken(refreshTokenCookie);
+
+        // 새 액세스 토큰을 쿠키로 추가
+        Cookie accessTokenCookie = new Cookie("accessToken", accessToken.getAccessToken());
+        accessTokenCookie.setHttpOnly(true); // 보안 설정
+        accessTokenCookie.setSecure(true);   // HTTPS에서만 전송
+        accessTokenCookie.setPath("/");      // 모든 경로에서 접근 가능
+        accessTokenCookie.setMaxAge((int) ACCESS_TOKEN_EXPIRATION_TIME / 1000); // 만료 시간 설정
+        response.addCookie(accessTokenCookie);
+
+        return ApiResponse.onSuccess(SuccessStatus._CREATED_ACCESS_TOKEN, null);
     }
 }

--- a/src/main/java/com/example/oauthjwt/oauth2/infra/jwt/JWTFilter.java
+++ b/src/main/java/com/example/oauthjwt/oauth2/infra/jwt/JWTFilter.java
@@ -1,0 +1,68 @@
+package com.example.oauthjwt.oauth2.infra.jwt;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class JWTFilter extends OncePerRequestFilter {
+
+    private final JWTUtil jwtUtil;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        try {
+            log.info("JWTFilter: 요청 처리 시작 " );
+
+            // 쿠키에서 액세스 토큰 가져오기
+            String accessToken = getAccessTokenFromCookies(request);
+            if (accessToken != null) {
+                // 토큰 검증
+                jwtUtil.validateToken(accessToken);
+
+                // 유효한 경우 사용자 인증 설정
+                String userId = jwtUtil.getUserIdFromToken(accessToken);
+                setAuthentication(request, userId);
+            }
+        } catch (Exception e) {
+            // 토큰이 유효하지 않거나 인증이 실패한 경우 예외 처리
+            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);  // 401 Unauthorized 응답
+            return;  // 필터 체인을 종료
+        }
+        filterChain.doFilter(request, response);
+    }
+
+    // 쿠키에서 액세스 토큰 추출
+    private String getAccessTokenFromCookies(HttpServletRequest request) {
+        if (request.getCookies() != null) {
+            for (Cookie cookie : request.getCookies()) {
+                if ("accessToken".equals(cookie.getName())) {
+                    return cookie.getValue();
+                }
+            }
+        }
+        return null;
+    }
+
+    private void setAuthentication(HttpServletRequest request, String userId) {
+        // Spring Security가 제공하는 UsernamePasswordAuthenticationToken을 사용
+        UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(userId, null, null);
+        authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+
+        // SecurityContextHolder에 인증 정보 설정
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+    }
+}

--- a/src/main/java/com/example/oauthjwt/oauth2/infra/jwt/JWTUtil.java
+++ b/src/main/java/com/example/oauthjwt/oauth2/infra/jwt/JWTUtil.java
@@ -138,4 +138,17 @@ public class JWTUtil {
             throw new TokenException(TokenErrorResult.INVALID_TOKEN);
         }
     }
+    public boolean validateToken(String token) {
+        try {
+            Jwts.parser()
+                    .setSigningKey(this.getSigningKey())
+                    .build()
+                    .parseClaimsJws(token);  // 토큰의 유효성 검증
+            log.info("유효한 토큰입니다.");
+            return true; // 유효한 토큰이면 true 반환
+        } catch (JwtException | IllegalArgumentException e) {
+            log.warn("유효하지 않은 토큰입니다.");
+            throw new TokenException(TokenErrorResult.INVALID_TOKEN);  // 토큰이 유효하지 않으면 예외 처리
+        }
+    }
 }

--- a/src/main/java/com/example/oauthjwt/user/domain/repository/UserRepository.java
+++ b/src/main/java/com/example/oauthjwt/user/domain/repository/UserRepository.java
@@ -8,6 +8,6 @@ import java.util.UUID;
 
 public interface UserRepository {
     Optional<User> findByUserId(UUID userId);
-    Optional<User> findByProviderId(String providerId);
+    Optional<User> findByProvider(String provide);
     void save(User user);
 }

--- a/src/main/java/com/example/oauthjwt/user/infra/repository/JpaUserRepository.java
+++ b/src/main/java/com/example/oauthjwt/user/infra/repository/JpaUserRepository.java
@@ -14,5 +14,5 @@ public interface JpaUserRepository extends JpaRepository<UserEntity, Long> {
     @Query("SELECT u FROM UserEntity u WHERE u.userId = :userId")
     Optional<UserEntity> findByUserId(UUID userId);
 
-    Optional<UserEntity> findByProviderId(String providerId);
+    Optional<UserEntity> findByProvider(String provider);
 }

--- a/src/main/java/com/example/oauthjwt/user/infra/repository/UserAdapter.java
+++ b/src/main/java/com/example/oauthjwt/user/infra/repository/UserAdapter.java
@@ -22,9 +22,9 @@ public class UserAdapter implements UserRepository {
     }
 
     @Override
-    public Optional<User> findByProviderId(String providerId) {
+    public Optional<User> findByProvider(String provider) {
         // Optional을 사용하여 null 체크 처리
-        return jpaUserRepository.findByProviderId(providerId)
+        return jpaUserRepository.findByProvider(provider)
                 .map(UserEntity::toDomain);
     }
 


### PR DESCRIPTION
과정설명

1.http://localhost:8080/login -> kakao 클릭
2. 카카오 로그인 하기
3. 위에 url 에 뜨는 register token 값 복사
4. 포스트맨으로 http://localhost:8080/api/v1/register  (post) , header 에 Authorization 값에 register token 복사한거 넣기
바디값에:
{
    "name":"박경린",
    "phone":"01020089222"
}
이런식으로 넣으면 db 에 들어감

5. 그리고 다시 http://localhost:8080/login
하면 f12 개발자도구에 cookies 값에 access token , refresh token 값 들어감


추가 내용:
- jwt 검증하는 jwt 필터 추가  --> 로그에  jwt filter 돌아가는지 찍힘
- loginsuccesshandler 에 기존 유저면 쿠키에 토큰 추가